### PR TITLE
Fix missing CN for apps without existing certificate

### DIFF
--- a/src/main/java/com/hermesworld/ais/galapagos/uisupport/controller/ApplicationCnDto.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/uisupport/controller/ApplicationCnDto.java
@@ -1,0 +1,24 @@
+package com.hermesworld.ais.galapagos.uisupport.controller;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@JsonSerialize
+public class ApplicationCnDto {
+
+    private String applicationId;
+
+    private String name;
+
+    private String cn;
+
+    public ApplicationCnDto(String applicationId, String name, String cn) {
+        this.applicationId = applicationId;
+        this.name = name;
+        this.cn = cn;
+    }
+
+}

--- a/src/main/java/com/hermesworld/ais/galapagos/uisupport/controller/UISupportController.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/uisupport/controller/UISupportController.java
@@ -10,6 +10,7 @@ import com.hermesworld.ais.galapagos.kafka.util.KafkaTopicConfigHelper;
 import com.hermesworld.ais.galapagos.naming.NamingService;
 import com.hermesworld.ais.galapagos.topics.config.GalapagosTopicConfig;
 import com.hermesworld.ais.galapagos.topics.service.TopicService;
+import com.hermesworld.ais.galapagos.util.CertificateUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.config.TopicConfig;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -183,6 +184,13 @@ public class UISupportController {
                 .map(id -> kafkaClusters.getCaManager(id)
                         .map(caMan -> caMan.supportsDeveloperCertificates() ? id : null).orElse(null))
                 .filter(id -> id != null).collect(Collectors.toList());
+    }
+
+    @GetMapping(value = "/api/util/common-name/{applicationId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ApplicationCnDto getApplicationCommonName(@PathVariable String applicationId) {
+        return applicationsService.getKnownApplication(applicationId)
+                .map(app -> new ApplicationCnDto(app.getId(), app.getName(), CertificateUtil.toAppCn(app.getName())))
+                .orElseThrow(notFound);
     }
 
     private String getTopicNameSuggestion(QueryTopicCreateDefaultsDto query) {

--- a/ui/src/app/layout/applications/applications.component.html
+++ b/ui/src/app/layout/applications/applications.component.html
@@ -141,7 +141,6 @@
                                 <div class="radio">
                                     <label>
                                         <!--suppress TypeScriptUnresolvedVariable -->
-                                        <input type="radio" value="noCsr" name="hasCsr"
                                         <input id="noCsrRadio" type="radio" value="noCsr" name="noCsr"
                                                [(ngModel)]="certificateCreationType"
                                                [disabled]="certificateDlgData.environment?.production"/>&nbsp;<span

--- a/ui/src/app/layout/applications/applications.component.ts
+++ b/ui/src/app/layout/applications/applications.component.ts
@@ -186,6 +186,13 @@ export class ApplicationsComponent implements OnInit {
                 this.certificateDlgData.expiryWarningHtml = this.currentLang.pipe(mergeMap(lang =>
                     this.translateService.get(expiryWarnLevel === 'danger' ? 'CERTIFICATE_EXPIRED_HTML' : 'CERTIFICATE_EXPIRY_HTML',
                         { expiryDate: moment(isoExpiryDate).locale(lang).format('L') })));
+            } else {
+                this.certificateDlgData.commonName = 'app';
+                this.certificateDlgData.keyfileName = 'app.key';
+                this.certificateService.getApplicationCn(app.id).then(cn => {
+                    this.certificateDlgData.commonName = cn;
+                    this.certificateDlgData.keyfileName = this.certificateDlgData.commonName + '_' + env.id + '.key';
+                });
             }
             this.modalService.open(content, { ariaLabelledBy: 'modal-title', size: 'lg', windowClass: 'modal-xxl' });
         });

--- a/ui/src/app/shared/modules/openssl-command/openssl-command.component.ts
+++ b/ui/src/app/shared/modules/openssl-command/openssl-command.component.ts
@@ -1,11 +1,11 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
 
 @Component({
     selector: 'app-openssl-command',
     templateUrl: './openssl-command.component.html',
     styleUrls: ['./openssl-command.component.scss']
 })
-export class OpensslCommandComponent implements OnInit {
+export class OpensslCommandComponent implements OnInit, OnChanges {
     @Input() commonName: string;
     @Input() orgUnitName: string;
     @Input() keyfileName: string;
@@ -21,6 +21,10 @@ export class OpensslCommandComponent implements OnInit {
     }
 
     ngOnInit() {
+        this.updateCommand();
+    }
+
+    ngOnChanges(changes) {
         this.updateCommand();
     }
 

--- a/ui/src/app/shared/services/certificates.service.ts
+++ b/ui/src/app/shared/services/certificates.service.ts
@@ -60,6 +60,10 @@ export class CertificateService {
             this.http.get('/api/certificates/' + applicationId).pipe(map(val => val as ApplicationCertificate[])));
     }
 
+    public getApplicationCn(applicationId: string): Promise<string> {
+        return this.http.get('/api/util/common-name/' + applicationId).pipe(map(val => (val as any).cn)).toPromise();
+    }
+
     public getApplicationCertificatesPromise(applicationId: string): Promise<ApplicationCertificate[]> {
         return this.getApplicationCertificates(applicationId).getObservable().pipe(take(1)).toPromise();
     }


### PR DESCRIPTION
PR #24 introduced a bug where no CN is calculated (in the UI) for applications not yet having a certificate. This led to errorneous openssl commands being displayed.

This PR had to introduce a uisupport endpoint for calculating the CN for a given application. Before #24, this logic was duplicated in the UI (with slight differences to backend), but we wanted to remove this duplication, so the endpoint exposes this logic to the UI.