### PR TITLE
Add ESLint rules for spacing related to keywords

### DIFF
--- a/ui/.eslintrc.json
+++ b/ui/.eslintrc.json
@@ -93,7 +93,9 @@
                     "error",
                     "always"
                 ],
-                "object-shorthand": "off"
+                "object-shorthand": "off",
+                "keyword-spacing": "error",
+                "space-before-blocks": "error"
             }
         },
         {


### PR DESCRIPTION
With current setup, our ESLint rules allowed things like this:

```typescript
  if(someCondition){
```

Which should be

```typescript
  if (someCondition) {
```

This change adds these rules as errors to the ESLint config, so developers with wrong IDE settings encounter these latest during the Linter run.