### PR TITLE
Use correct service account ID field

### DIFF
--- a/ui/src/app/layout/applications/application-block.component.ts
+++ b/ui/src/app/layout/applications/application-block.component.ts
@@ -54,7 +54,7 @@ export class ApplicationBlockComponent implements OnChanges {
 
     expiryDateString: Observable<string>;
 
-    serviceAccountId: number;
+    serviceAccountId: string;
 
     constructor(private apiKeyService: ApiKeyService, public environmentsService: EnvironmentsService,
                 private certificateService: CertificateService, private translateService: TranslateService) {
@@ -88,7 +88,7 @@ export class ApplicationBlockComponent implements OnChanges {
                         }
 
                         this.apiKey = keys.authentications[env.id].authentication['apiKey'];
-                        this.serviceAccountId = keys.authentications[env.id].authentication['serviceAccountId'];
+                        this.serviceAccountId = keys.authentications[env.id].authentication['userId'];
                         return keys.authentications[env.id].authentication as ApplicationApiKey;
                     };
 

--- a/ui/src/styles/_accordion-fixes.scss
+++ b/ui/src/styles/_accordion-fixes.scss
@@ -1,0 +1,173 @@
+/*
+Enables ng-bootstrap Accordion component to work with old Bootstrap (adds missing style classes).
+ */
+
+@import "bootstrap/variables";
+@import "bootstrap/functions";
+@import "bootstrap/mixins/border-radius";
+@import "bootstrap/mixins/transition";
+
+// Tint a color: mix a color with white
+@function tint-color($color, $weight) {
+    @return mix(white, $color, $weight);
+}
+
+// Shade a color: mix a color with black
+@function shade-color($color, $weight) {
+    @return mix(black, $color, $weight);
+}
+
+$accordion-padding-y: 1rem;
+$accordion-padding-x: 1.25rem;
+$accordion-color: $body-color;
+$accordion-bg: $body-bg;
+$accordion-border-width: $border-width;
+$accordion-border-color: rgba($black, .125);
+$accordion-border-radius: $border-radius;
+$accordion-inner-border-radius: subtract($accordion-border-radius, $accordion-border-width);
+
+$accordion-body-padding-y: $accordion-padding-y;
+$accordion-body-padding-x: $accordion-padding-x;
+
+$accordion-button-padding-y: $accordion-padding-y;
+$accordion-button-padding-x: $accordion-padding-x;
+$accordion-button-color: $accordion-color;
+$accordion-button-bg: $accordion-bg;
+$accordion-transition: $btn-transition, border-radius .15s ease;
+$accordion-button-active-bg: tint-color($component-active-bg, 90%);
+$accordion-button-active-color: shade-color($primary, 10%);
+
+$accordion-button-focus-border-color: $input-focus-border-color;
+$accordion-button-focus-box-shadow: $btn-focus-box-shadow;
+
+$accordion-icon-width: 1.25rem;
+$accordion-icon-color: $accordion-color;
+$accordion-icon-active-color: $accordion-button-active-color;
+$accordion-icon-transition: transform .2s ease-in-out;
+$accordion-icon-transform: rotate(-180deg);
+
+$accordion-button-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$accordion-icon-color}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+$accordion-button-active-icon: url("data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='#{$accordion-icon-active-color}'><path fill-rule='evenodd' d='M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z'/></svg>");
+
+//
+// Base styles
+//
+
+.accordion-button {
+    position: relative;
+    display: flex;
+    align-items: center;
+    width: 100%;
+    padding: $accordion-button-padding-y $accordion-button-padding-x;
+    font-size: $font-size-base;
+    color: $accordion-button-color;
+    text-align: left; // Reset button style
+    background-color: $accordion-button-bg;
+    border: 0;
+    @include border-radius(0);
+    overflow-anchor: none;
+    @include transition($accordion-transition);
+
+    &:not(.collapsed) {
+        color: $accordion-button-active-color;
+        background-color: $accordion-button-active-bg;
+        box-shadow: inset 0 ($accordion-border-width * -1) 0 $accordion-border-color;
+
+        &::after {
+            background-image: escape-svg($accordion-button-active-icon);
+            transform: $accordion-icon-transform;
+        }
+    }
+
+    // Accordion icon
+    &::after {
+        flex-shrink: 0;
+        width: $accordion-icon-width;
+        height: $accordion-icon-width;
+        margin-left: auto;
+        content: "";
+        background-image: escape-svg($accordion-button-icon);
+        background-repeat: no-repeat;
+        background-size: $accordion-icon-width;
+    }
+
+    &:hover {
+        z-index: 2;
+    }
+
+    &:focus {
+        z-index: 3;
+        border-color: $accordion-button-focus-border-color;
+        outline: 0;
+        box-shadow: $accordion-button-focus-box-shadow;
+    }
+}
+
+.accordion-header {
+    margin-bottom: 0;
+}
+
+.accordion-item {
+    background-color: $accordion-bg;
+    border: $accordion-border-width solid $accordion-border-color;
+
+    &:first-of-type {
+        @include border-top-radius($accordion-border-radius);
+
+        .accordion-button {
+            @include border-top-radius($accordion-inner-border-radius);
+        }
+    }
+
+    &:not(:first-of-type) {
+        border-top: 0;
+    }
+
+    // Only set a border-radius on the last item if the accordion is collapsed
+    &:last-of-type {
+        @include border-bottom-radius($accordion-border-radius);
+
+        .accordion-button {
+            &.collapsed {
+                @include border-bottom-radius($accordion-inner-border-radius);
+            }
+        }
+
+        .accordion-collapse {
+            @include border-bottom-radius($accordion-border-radius);
+        }
+    }
+}
+
+.accordion-body {
+    padding: $accordion-body-padding-y $accordion-body-padding-x;
+}
+
+
+// Flush accordion items
+//
+// Remove borders and border-radius to keep accordion items edge-to-edge.
+
+.accordion-flush {
+    .accordion-collapse {
+        border-width: 0;
+    }
+
+    .accordion-item {
+        border-right: 0;
+        border-left: 0;
+        @include border-radius(0);
+
+        &:first-child {
+            border-top: 0;
+        }
+
+        &:last-child {
+            border-bottom: 0;
+        }
+
+        .accordion-button {
+            @include border-radius(0);
+        }
+    }
+}

--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -179,6 +179,7 @@
 }
 
 @import "bootstrap/bootstrap";
+@import "accordion-fixes";
 
 @media print {
     .breadcrumb {


### PR DESCRIPTION
This fixes an inconsistency between #226 and 231, as the service account ID now can be found in field `userId` of the authentication info for an application.

Additionally, this fixes the Accordion component, which had been rendered incorrectly since upgrade of Angular and ng-bootstrap libraries. New ng-bootstrap now only supports BS 5 version of Accordion, and this change adds the BS 5 specific styles for Accordion to Galapagos UI, so it also works with BS 4.x.

Nevertheless, we will have to upgrade to BS 5 soon.