### PR TITLE
Change Maven/npm integration to better work on "clean" systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,10 +247,20 @@
 						<phase>prepare-package</phase>
 					</execution>
 					<execution>
+						<id>install-npm-packages</id>
+						<goals>
+							<goal>npm</goal>
+						</goals>
+						<phase>prepare-package</phase>
+					</execution>
+					<execution>
 						<id>build-ui</id>
 						<goals>
 							<goal>npm</goal>
 						</goals>
+						<configuration>
+							<arguments>run build-from-maven</arguments>
+						</configuration>
 						<phase>prepare-package</phase>
 					</execution>
 				</executions>
@@ -258,7 +268,6 @@
 					<nodeVersion>${node.version}</nodeVersion>
 					<workingDirectory>${basedir}/ui</workingDirectory>
 					<installDirectory>${project.build.directory}</installDirectory>
-					<arguments>run build-from-maven</arguments>
 				</configuration>
 			</plugin>
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
         "ng": "ng",
         "start": "ng serve --proxy-config proxy.conf.json",
         "build": "ng build --configuration production --base-href /app/",
-        "build-from-maven": "npm install && ng build --configuration production --base-href /app/ --output-path ../target/classes/static/app",
+        "build-from-maven": "ng build --configuration production --base-href /app/ --output-path ../target/classes/static/app",
         "test": "ng test",
         "lint": "ng lint galapagos"
     },


### PR DESCRIPTION
On clean systems without a global npm, the npm script "build-from-maven" fails, as the npm installed from the frontend-maven-plugin is not available as command from within npm scripts.

This is now solved by invoking "npm install" directly via plugin mechanisms.