### PR TITLE
Hotfix for UI blocking in dark mode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.hermesworld.ais</groupId>
 	<artifactId>galapagos</artifactId>
-	<version>2.6.0-SNAPSHOT</version>
+	<version>2.6.1-SNAPSHOT</version>
 	<name>Galapagos</name>
 	<description>A self-service tool for managing Kafka Topics and associated JSON schemas.</description>
 

--- a/ui/src/styles/app.scss
+++ b/ui/src/styles/app.scss
@@ -22,6 +22,10 @@
     $green: #155622;
     $topicSettings: #121212;
     $defaultInputValue: #E0F8E0;
+
+    // Fixes another incompatibility of ng-bootstrap 13.0.0 and Bootstrap 4.x
+    $zindex-modal: 1055;
+
     @import "bootstrap/bootstrap";
 }
 


### PR DESCRIPTION
This fixes a UI bug introduced by latest ng-bootstrap version in combination with Bootstrap 4.x. A workaround previously was in place for "light mode", but forgotten for "dark mode".