### PR TITLE
Fix missing topic config in demo setup

### DIFF
--- a/demo-ccloud/setup-demo.sh
+++ b/demo-ccloud/setup-demo.sh
@@ -171,7 +171,7 @@ createCloudApiKey () {
 
 importDemoData () {
   echo "Creating known-applications topic (if not already exists)..."
-  "$CCLOUD_CLI" kafka topic create galapagos.internal.known-applications --cluster "$PROD_CLUSTER_ID" --environment "$GALA_ENV_ID" --if-not-exists --partitions 1 || exit 1
+  "$CCLOUD_CLI" kafka topic create galapagos.internal.known-applications --cluster "$PROD_CLUSTER_ID" --environment "$GALA_ENV_ID" --if-not-exists --partitions 1 --config "cleanup.policy=compact" || exit 1
 
   echo "Importing Demo data..."
   "$CCLOUD_CLI" kafka topic produce galapagos.internal.known-applications --parse-key --api-secret "$PROD_API_SECRET" \


### PR DESCRIPTION
The demo setup was missing the "cleanup.policy=compact" configuration for the known-applications topic. This lead to demo data being deleted after 7 days.
