### PR TITLE
Hotfix: Fix Confluent Cloud changed "next" URI syntax for pagination

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	</parent>
 	<groupId>com.hermesworld.ais</groupId>
 	<artifactId>galapagos</artifactId>
-	<version>2.6.2</version>
+	<version>2.6.3-SNAPSHOT</version>
 	<name>Galapagos</name>
 	<description>A self-service tool for managing Kafka Topics and associated JSON schemas.</description>
 

--- a/src/main/java/com/hermesworld/ais/galapagos/ccloud/apiclient/ConfluentCloudApiClient.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/ccloud/apiclient/ConfluentCloudApiClient.java
@@ -44,6 +44,8 @@ public class ConfluentCloudApiClient {
 
     private static final String BASE_URL = "https://api.confluent.cloud";
 
+    private final String baseUrl;
+
     private final WebClient client;
 
     private final boolean idCompatMode;
@@ -57,6 +59,7 @@ public class ConfluentCloudApiClient {
      *                     ACL related purposes. See description of this class for details.
      */
     public ConfluentCloudApiClient(String baseUrl, String apiKey, String apiSecret, boolean idCompatMode) {
+        this.baseUrl = baseUrl;
         this.client = WebClient.builder().baseUrl(baseUrl)
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
                 .defaultHeader(HttpHeaders.AUTHORIZATION, buildAuth(apiKey, apiSecret)).build();
@@ -189,7 +192,7 @@ public class ConfluentCloudApiClient {
         // Confluent Cloud API) to %253D.
         URI realUri;
         try {
-            realUri = new URI(BASE_URL).resolve(new URI(localUri));
+            realUri = new URI(baseUrl).resolve(new URI(localUri));
         }
         catch (URISyntaxException e) {
             log.error("Could not perform REST API request due to invalid URI {}", localUri, e);


### PR DESCRIPTION
Confluent recently changed their URI syntax of their "next" URI in paginated responses, so Base64 "equal" signs are URI encoded (which is, frankly speaking, correct). As we split this string and use Spring's URI Builder to construct a new URI out of this, the `%3D` in the URI is encoded **again**, resulting in `%253D`, thus not working.

This hotfix constructs the target URI without using the URI Builder to avoid this issue.