### PR TITLE
Limit app names to 50 characters for Service Account Display Name

### DIFF
--- a/src/main/java/com/hermesworld/ais/galapagos/ccloud/auth/ConfluentCloudAuthenticationModule.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/ccloud/auth/ConfluentCloudAuthenticationModule.java
@@ -92,9 +92,12 @@ public class ConfluentCloudAuthenticationModule implements KafkaAuthenticationMo
         // reset internal ID cache
         serviceAccountNumericIds.clear();
 
+        String shortenedAppName = applicationNormalizedName.substring(0,
+                Math.min(50, applicationNormalizedName.length()));
+
         return findServiceAccountForApp(applicationId)
                 .thenCompose(account -> account.map(a -> CompletableFuture.completedFuture(a))
-                        .orElseGet(() -> client.createServiceAccount("application-" + applicationNormalizedName,
+                        .orElseGet(() -> client.createServiceAccount("application-" + shortenedAppName,
                                 appServiceAccountDescription(applicationId)).toFuture()))
                 .thenCompose(account -> client.createApiKey(config.getEnvironmentId(), config.getClusterId(),
                         apiKeyDesc, account.getResourceId()).toFuture())
@@ -213,7 +216,7 @@ public class ConfluentCloudAuthenticationModule implements KafkaAuthenticationMo
     /**
      * Upgrades a given "old" authentication metadata object. Is used by admin job "update-confluent-auth-metadata" to
      * e.g. add numeric IDs and Service Account Resource IDs.
-     * 
+     *
      * @param oldAuthMetadata Potentially "old" authentication metadata (function determines if update is required).
      * @return The "updated" metadata, or the unchanged metadata if already filled with new fields. As a future as an
      *         API call may be required to determine required information (e.g. internal numeric ID for a service

--- a/src/test/java/com/hermesworld/ais/galapagos/ccloud/ConfluentCloudAuthenticationModuleTest.java
+++ b/src/test/java/com/hermesworld/ais/galapagos/ccloud/ConfluentCloudAuthenticationModuleTest.java
@@ -14,6 +14,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.test.util.ReflectionTestUtils;
 import reactor.core.publisher.Mono;
 
@@ -377,11 +378,28 @@ public class ConfluentCloudAuthenticationModuleTest {
         try {
             authenticationModule.createDeveloperAuthentication("test-user@test.demo", new JSONObject()).get();
             fail("Expected an exception when developer auth is not enabled");
-        }
-        catch (ExecutionException e) {
+        } catch (ExecutionException e) {
             // OK
             assertTrue(e.getCause() instanceof IllegalStateException);
         }
+    }
+
+    @Test
+    public void testShortenAppNames() throws Exception {
+        ServiceAccountSpec testServiceAccount = new ServiceAccountSpec();
+        testServiceAccount.setDisplayName("Test Display Name");
+        testServiceAccount.setResourceId("sa-xy123");
+        testServiceAccount.setDescription("Test description");
+        ApiKeySpec apiKey = newApiKey("TESTKEY", "testSecret", "sa-xy123");
+
+        when(client.listServiceAccounts()).thenReturn(Mono.just(List.of()));
+        ArgumentCaptor<String> displayNameCaptor = ArgumentCaptor.forClass(String.class);
+        when(client.createServiceAccount(displayNameCaptor.capture(), anyString())).thenReturn(Mono.just(testServiceAccount));
+        when(client.createApiKey(anyString(), anyString(), anyString(), anyString())).thenReturn(Mono.just(apiKey));
+
+        authenticationModule.createApplicationAuthentication("app-1", "A_very_long_strange_application_name_which_likely_exceeds_50_characters_whoever_names_such_applications", new JSONObject()).get();
+
+        assertTrue(displayNameCaptor.getValue().length() <= 64);
     }
 
 }

--- a/src/test/java/com/hermesworld/ais/galapagos/ccloud/ConfluentCloudAuthenticationModuleTest.java
+++ b/src/test/java/com/hermesworld/ais/galapagos/ccloud/ConfluentCloudAuthenticationModuleTest.java
@@ -378,7 +378,8 @@ public class ConfluentCloudAuthenticationModuleTest {
         try {
             authenticationModule.createDeveloperAuthentication("test-user@test.demo", new JSONObject()).get();
             fail("Expected an exception when developer auth is not enabled");
-        } catch (ExecutionException e) {
+        }
+        catch (ExecutionException e) {
             // OK
             assertTrue(e.getCause() instanceof IllegalStateException);
         }
@@ -394,10 +395,13 @@ public class ConfluentCloudAuthenticationModuleTest {
 
         when(client.listServiceAccounts()).thenReturn(Mono.just(List.of()));
         ArgumentCaptor<String> displayNameCaptor = ArgumentCaptor.forClass(String.class);
-        when(client.createServiceAccount(displayNameCaptor.capture(), anyString())).thenReturn(Mono.just(testServiceAccount));
+        when(client.createServiceAccount(displayNameCaptor.capture(), anyString()))
+                .thenReturn(Mono.just(testServiceAccount));
         when(client.createApiKey(anyString(), anyString(), anyString(), anyString())).thenReturn(Mono.just(apiKey));
 
-        authenticationModule.createApplicationAuthentication("app-1", "A_very_long_strange_application_name_which_likely_exceeds_50_characters_whoever_names_such_applications", new JSONObject()).get();
+        authenticationModule.createApplicationAuthentication("app-1",
+                "A_very_long_strange_application_name_which_likely_exceeds_50_characters_whoever_names_such_applications",
+                new JSONObject()).get();
 
         assertTrue(displayNameCaptor.getValue().length() <= 64);
     }


### PR DESCRIPTION
Confluent has a hard limit of 64 characters for the display name of Service Accounts. As we set "application-" plus the normalized name of the application as the display name, this can get too long if the application name is very, very long.

For this case, we should shorten the application name to 50 characters to fit in the display name. This is what this fix does.