### PR TITLE
Add sorting to "additional producer" app list

### DIFF
--- a/ui/src/app/layout/topics/deletetopic/multiappproducer/topic-multiple-producer.component.ts
+++ b/ui/src/app/layout/topics/deletetopic/multiappproducer/topic-multiple-producer.component.ts
@@ -36,7 +36,9 @@ export class TopicMultipleProducerComponent implements OnInit {
         this.applicationsService.getRegisteredApplications(this.selectedEnvironment.id).then(
             registeredApps => {
                 this.selectableProducerApps = registeredApps.filter(producerApp => producerApp.id !== topicOwnerAppId
-                    && !this.topic.producers.includes(producerApp.id));
+                    && !this.topic.producers.includes(producerApp.id)).sort(
+                    (a, b) => a.name.localeCompare(b.name)
+                );
             });
     }
 


### PR DESCRIPTION
This fixes the missing sorting of the applications list in the dialog "Add producer" for a topic. Now, the applications are sorted alphabetically, so you can easier find an application.