### PR TITLE
Add feature toggle for enabling / disabling advanced config for topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -356,6 +356,11 @@
                     <groupId>com.google.cloud.tools</groupId>
                     <artifactId>jib-maven-plugin</artifactId>
                     <version>3.4.0</version>
+                    <configuration>
+                        <from>
+                            <image>eclipse-temurin:17-jre</image>
+                        </from>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -151,6 +151,8 @@ info.app.version=local-dev
 info.toggles.subscriptionApproval=true
 # Feature toggle for deleting a json schema even if the topic has subscribers
 info.toggles.schemaDeleteWithSub=false
+# Feature toggle for enabling / disabling "advanced configuration" for topics (editing topic config properties via UI)
+info.toggles.showAdvancedTopicConfig=true
 # Specify a value to display as "instance name" in the top bar, to distinguish multiple Galapagos installations, e.g. testing and production.
 info.galapagos.instanceName=
 # Banner location

--- a/ui/src/app/layout/topics/deletetopic/delete-topic.component.html
+++ b/ui/src/app/layout/topics/deletetopic/delete-topic.component.html
@@ -5,12 +5,14 @@
                 class="fas fa-exclamation-triangle me-3"></i>{{ 'Danger Zone' | translate }}
             </div>
             <div class="card-body">
-                <p>{{ 'TOPIC_CONFIG_TEXT' | translate }}</p>
-                <button class="btn btn-warning"
-                        [routerLink]="'/topics/' + topicName + '/config'">
-                    <i class="fas fa-wrench me-3"></i>{{ 'Advanced Configuration' | translate }}
-                </button>
-                <hr>
+                <div *ngIf="showAdvancedTopicConfig | async">
+                    <p>{{ 'TOPIC_CONFIG_TEXT' | translate }}</p>
+                    <button class="btn btn-warning"
+                            [routerLink]="'/topics/' + topicName + '/config'">
+                        <i class="fas fa-wrench me-3"></i>{{ 'Advanced Configuration' | translate }}
+                    </button>
+                    <hr>
+                </div>
                 <div *ngIf="topic.topicType !== 'COMMANDS' && !selectedEnvironment.stagingOnly">
                     <p>{{ 'ADD_PRODUCER_HTML' | translate }}</p>
                     <button class="btn btn-warning"

--- a/ui/src/app/layout/topics/deletetopic/delete-topic.component.ts
+++ b/ui/src/app/layout/topics/deletetopic/delete-topic.component.ts
@@ -4,7 +4,9 @@ import { EnvironmentsService, KafkaEnvironment } from '../../../shared/services/
 import { ToastService } from '../../../shared/modules/toast/toast.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Router } from '@angular/router';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, Observable } from 'rxjs';
+import { ServerInfoService } from "../../../shared/services/serverinfo.service";
+import { map } from "rxjs/operators";
 
 @Component({
     selector: 'app-delete-topic-component',
@@ -24,13 +26,17 @@ export class DeleteTopicComponent {
 
     topicNameConfirmText = '';
 
+    showAdvancedTopicConfig: Observable<boolean>;
+
     constructor(
         private toasts: ToastService,
         private topicService: TopicsService,
         private environmentsService: EnvironmentsService,
+        serverInfoService: ServerInfoService,
         private modalService: NgbModal,
         private router: Router
     ) {
+        this.showAdvancedTopicConfig = serverInfoService.getServerInfo().pipe(map(info => info.toggles.showAdvancedTopicConfig === "true"));
     }
 
     openDeleteConfirmDlg(content: any) {

--- a/ui/src/app/layout/topics/schemasection/schema-section.component.spec.ts
+++ b/ui/src/app/layout/topics/schemasection/schema-section.component.spec.ts
@@ -141,7 +141,8 @@ describe('SchemaSectionComponent', () => {
             },
             toggles: {
                 subscriptionApproval: 'false',
-                schemaDeleteWithSub: 'true'
+                schemaDeleteWithSub: 'true',
+                showAdvancedTopicConfig: 'true'
 
             },
             galapagos:{
@@ -220,7 +221,8 @@ describe('SchemaSectionComponent', () => {
             },
             toggles: {
                 subscriptionApproval: 'false',
-                schemaDeleteWithSub: 'false'
+                schemaDeleteWithSub: 'false',
+                showAdvancedTopicConfig: 'true'
             },
             galapagos:{
                 instanceName:'test-instance'
@@ -283,7 +285,8 @@ describe('SchemaSectionComponent', () => {
             },
             toggles: {
                 subscriptionApproval: 'false',
-                schemaDeleteWithSub: 'false'
+                schemaDeleteWithSub: 'false',
+                showAdvancedTopicConfig: 'true'
             },
             galapagos:{
                 instanceName:'test-instance'

--- a/ui/src/app/shared/services/serverinfo.service.ts
+++ b/ui/src/app/shared/services/serverinfo.service.ts
@@ -13,6 +13,8 @@ export interface TogglesInfo {
     subscriptionApproval: string;
 
     schemaDeleteWithSub: string;
+
+    showAdvancedTopicConfig: string;
 }
 
 export interface ServerInfo {


### PR DESCRIPTION
Adds a feature toggle for enabling / disabling the "advanced config" sub-section on the Topics page. Currently, this is only a UI feature; the related backend API is still enabled. This is required for an urgent issue at our company.