### PR TITLE
Upgrade Spring Boot to 3.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.2.6</version>
+        <version>3.2.7</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
     <groupId>com.hermesworld.ais</groupId>


### PR DESCRIPTION
This fixes [CVE-2024-34750](https://www.cve.org/CVERecord?id=CVE-2024-34750), although Galapagos is most likely unaffected.