### PR TITLE
Support "invalid" marker for applications

### DIFF
--- a/src/main/java/com/hermesworld/ais/galapagos/applications/KnownApplication.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/applications/KnownApplication.java
@@ -7,11 +7,8 @@ import java.util.Set;
 /**
  * An application "known" to Galapagos. The list of all known applications form the basis from which the users can
  * select "their" applications and create Application Owner Requests for. Known applications must be registered on a
- * Kafka Cluster using
- * {@link ApplicationsService#createApplicationCertificateAndPrivateKey(String, String, String, java.io.OutputStream)}
- * or
- * {@link ApplicationsService#createApplicationCertificateFromCsr(String, String, String, String, java.io.OutputStream)}
- * to retrieve a Client Certificate for this application.
+ * Kafka Cluster using one of the registration methods in ApplicationService to retrieve Kafka Client Credentials for
+ * this application.
  *
  * @author AlbrechtFlo
  *
@@ -60,4 +57,11 @@ public interface KnownApplication {
      */
     List<BusinessCapability> getBusinessCapabilities();
 
+    /**
+     * Returns a flag if the application should be treated as "valid". "Invalid" usually means that the system providing
+     * the list of applications no longer would provide this application (e.g. EOL).
+     *
+     * @return A flag if the application should be treated as "valid" or not.
+     */
+    boolean isValid();
 }

--- a/src/main/java/com/hermesworld/ais/galapagos/applications/controller/ApplicationsController.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/applications/controller/ApplicationsController.java
@@ -325,7 +325,7 @@ public class ApplicationsController {
         }
         return new KnownApplicationDto(app.getId(), app.getName(),
                 app.getInfoUrl() == null ? null : app.getInfoUrl().toString(), toCapDtos(app.getBusinessCapabilities()),
-                new ArrayList<>(app.getAliases()));
+                new ArrayList<>(app.getAliases()), app.isValid());
     }
 
     private List<BusinessCapabilityDto> toCapDtos(List<? extends BusinessCapability> caps) {

--- a/src/main/java/com/hermesworld/ais/galapagos/applications/controller/KnownApplicationDto.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/applications/controller/KnownApplicationDto.java
@@ -1,29 +1,32 @@
 package com.hermesworld.ais.galapagos.applications.controller;
 
-import java.util.List;
-
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class KnownApplicationDto {
 
-    private String id;
+    private final String id;
 
-    private String name;
+    private final String name;
 
-    private String infoUrl;
+    private final String infoUrl;
 
-    private List<BusinessCapabilityDto> businessCapabilities;
+    private final List<BusinessCapabilityDto> businessCapabilities;
 
-    private List<String> aliases;
+    private final List<String> aliases;
+
+    private final boolean valid;
 
     public KnownApplicationDto(String id, String name, String infoUrl, List<BusinessCapabilityDto> businessCapabilities,
-            List<String> aliases) {
+                               List<String> aliases, boolean valid) {
         this.id = id;
         this.name = name;
         this.infoUrl = infoUrl;
         this.businessCapabilities = businessCapabilities;
         this.aliases = aliases;
+        this.valid = valid;
     }
 
 }

--- a/src/main/java/com/hermesworld/ais/galapagos/applications/controller/KnownApplicationDto.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/applications/controller/KnownApplicationDto.java
@@ -20,7 +20,7 @@ public class KnownApplicationDto {
     private final boolean valid;
 
     public KnownApplicationDto(String id, String name, String infoUrl, List<BusinessCapabilityDto> businessCapabilities,
-                               List<String> aliases, boolean valid) {
+            List<String> aliases, boolean valid) {
         this.id = id;
         this.name = name;
         this.infoUrl = infoUrl;

--- a/src/main/java/com/hermesworld/ais/galapagos/applications/impl/KnownApplicationImpl.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/applications/impl/KnownApplicationImpl.java
@@ -1,34 +1,41 @@
 package com.hermesworld.ais.galapagos.applications.impl;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.hermesworld.ais.galapagos.applications.BusinessCapability;
 import com.hermesworld.ais.galapagos.applications.KnownApplication;
 import com.hermesworld.ais.galapagos.util.HasKey;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 @JsonSerialize
 @Slf4j
 public class KnownApplicationImpl implements KnownApplication, HasKey, Comparable<KnownApplicationImpl> {
 
-    private String id;
+    private final String id;
 
-    private String name;
+    private final String name;
 
+    @Setter
     private List<String> aliases;
 
+    @Setter
     private String infoUrl;
 
+    @Setter
     private List<BusinessCapabilityImpl> businessCapabilities;
+
+    @Setter
+    private boolean valid;
 
     @JsonCreator
     public KnownApplicationImpl(@JsonProperty(value = "id", required = true) String id,
@@ -41,6 +48,7 @@ public class KnownApplicationImpl implements KnownApplication, HasKey, Comparabl
         }
         this.id = id;
         this.name = name;
+        this.valid = true;
     }
 
     @Override
@@ -63,10 +71,6 @@ public class KnownApplicationImpl implements KnownApplication, HasKey, Comparabl
         return this.aliases == null ? Collections.emptySet() : new HashSet<>(this.aliases);
     }
 
-    public void setAliases(List<String> aliases) {
-        this.aliases = aliases;
-    }
-
     @Override
     public URL getInfoUrl() {
         try {
@@ -78,25 +82,18 @@ public class KnownApplicationImpl implements KnownApplication, HasKey, Comparabl
         }
     }
 
-    public void setInfoUrl(String infoUrl) {
-        this.infoUrl = infoUrl;
-    }
-
     @Override
     public List<BusinessCapability> getBusinessCapabilities() {
-        return this.businessCapabilities == null ? Collections.emptyList()
-                : this.businessCapabilities.stream().collect(Collectors.toList());
-    }
-
-    public void setBusinessCapabilities(List<BusinessCapabilityImpl> businessCapabilities) {
-        this.businessCapabilities = businessCapabilities;
+        return this.businessCapabilities == null ? List.of() : List.copyOf(this.businessCapabilities);
     }
 
     @Override
-    public int compareTo(KnownApplicationImpl o) {
-        if (o == null) {
-            return 1;
-        }
+    public boolean isValid() {
+        return valid;
+    }
+
+    @Override
+    public int compareTo(@NonNull KnownApplicationImpl o) {
         return name.compareToIgnoreCase(o.name);
     }
 

--- a/ui/src/app/layout/admin/admin.component.html
+++ b/ui/src/app/layout/admin/admin.component.html
@@ -15,7 +15,6 @@
                                 id="table-complete-search"
                                 type="text"
                                 class="form-control"
-                                class="form-control"
                                 name="searchTerm"
                                 [(ngModel)]="state.searchTerm"
                                 (ngModelChange)="search()"

--- a/ui/src/app/layout/admin/admin.component.html
+++ b/ui/src/app/layout/admin/admin.component.html
@@ -38,8 +38,9 @@
                                 <td>{{ niceTimestamp(request.createdAt) | async }}</td>
                                 <td><ngb-highlight [result]="request.userName" [term]="state.searchTerm"></ngb-highlight></td>
                                 <td>
-                                    <a *ngIf="request.applicationInfoUrl" [href]="request.applicationInfoUrl" target="_blank"><ngb-highlight [result]="request.applicationName" [term]="state.searchTerm"></ngb-highlight></a>
-                                    <ngb-highlight *ngIf="!request.applicationInfoUrl" [result]="request.applicationName" [term]="state.searchTerm"></ngb-highlight></td>
+                                    <app-app-link *ngIf="request.appInfo" [app]="request.appInfo"
+                                                  [highlightText]="state.searchTerm"></app-app-link>
+                                    <span *ngIf="!request.appInfo">{{ request.applicationId }}</span>
                                 <td><span [innerHTML]="request.comments"></span></td>
                                 <td style="min-width: 9em">
                                     <span

--- a/ui/src/app/layout/admin/admin.component.ts
+++ b/ui/src/app/layout/admin/admin.component.ts
@@ -18,7 +18,7 @@ import { AuthService } from '../../shared/services/auth.service';
 
 interface TranslatedApplicationOwnerRequest extends ApplicationOwnerRequest {
     applicationName?: string;
-    applicationInfoUrl?: string;
+    appInfo?: ApplicationInfo;
 }
 
 
@@ -37,8 +37,10 @@ const translateApps: (requests: ApplicationOwnerRequest[], apps: ApplicationInfo
     (requests, apps) => {
         const appMap = {};
         apps.forEach(app => appMap[app.id] = app);
-        return requests.map(req => appMap[req.applicationId] ? { ...req, applicationName: appMap[req.applicationId].name || req.id,
-            applicationInfoUrl: appMap[req.applicationId].infoUrl } : req);
+        return requests.map(req => appMap[req.applicationId] ? {
+            ...req, applicationName: appMap[req.applicationId].name || req.applicationId,
+            appInfo: appMap[req.applicationId]
+        } : req);
     };
 
 const entityMap = {

--- a/ui/src/app/layout/admin/admin.module.ts
+++ b/ui/src/app/layout/admin/admin.module.ts
@@ -8,9 +8,10 @@ import { FormsModule } from '@angular/forms';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { SpinnerWhileModule } from 'src/app/shared/modules/spinner-while/spinner-while.module';
 import { AppSortableHeaderDirective } from './sortable.directive';
+import { AppLinkModule } from '../../shared/modules/app-link/app-link.module';
 
 @NgModule({
-    imports: [CommonModule, AdminRoutingModule, TranslateModule, FormsModule, NgbModule, SpinnerWhileModule],
+    imports: [CommonModule, AdminRoutingModule, TranslateModule, FormsModule, NgbModule, SpinnerWhileModule, AppLinkModule],
     declarations: [AdminComponent, AppSortableHeaderDirective]
 })
 export class AdminModule {}

--- a/ui/src/app/layout/applications/applications.component.html
+++ b/ui/src/app/layout/applications/applications.component.html
@@ -30,7 +30,8 @@
                                 for="app_picker">{{ 'Select Application' | translate }}</label>
                             <select class="form-select w-auto" name="appPicker" id="app_picker"
                                 [(ngModel)]="selectedApplicationForRequest">
-                                <option *ngFor="let app of availableApplications | async" [ngValue]="app">{{ app.name }}
+                                <option *ngFor="let app of availableApplications | async"
+                                        [ngValue]="app">{{ app.valid ? '' : '(!) ' }}{{ app.name }}
                                 </option>
                             </select>
                             <span class="ms-3 text-muted" [style.display]="appListLoading ? 'inline' : 'none'"><i

--- a/ui/src/app/layout/applications/applications.component.ts
+++ b/ui/src/app/layout/applications/applications.component.ts
@@ -8,7 +8,7 @@ import {
     ApplicationsService,
     UserApplicationInfo
 } from '../../shared/services/applications.service';
-import { combineLatest, Observable, of } from 'rxjs';
+import { combineLatest, firstValueFrom, Observable, of } from 'rxjs';
 import { toNiceTimestamp } from '../../shared/util/time-util';
 
 import { DateTime } from 'luxon';
@@ -22,6 +22,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { ApiKeyService } from '../../shared/services/apikey.service';
 import { ApplicationCertificate, CertificateService } from '../../shared/services/certificates.service';
 import { copy } from '../../shared/util/copy-util';
+import { AuthService } from '../../shared/services/auth.service';
 
 export interface UserApplicationInfoWithTopics extends UserApplicationInfo {
 
@@ -104,11 +105,12 @@ export class ApplicationsComponent implements OnInit {
         private topicsService: TopicsService,
         private toasts: ToastService,
         private translateService: TranslateService,
-        private certificateService: CertificateService
+        private certificateService: CertificateService,
+        private authService: AuthService
     ) {
     }
 
-    ngOnInit() {
+    async ngOnInit() {
         const now = DateTime.now();
 
         this.currentLang = this.translateService.onLangChange.pipe(map(evt => evt.lang))
@@ -116,12 +118,20 @@ export class ApplicationsComponent implements OnInit {
 
         const relevant = (req: ApplicationOwnerRequest) => DateTime.fromISO(req.lastStatusChangeAt)
             .minus(30, 'days') < now;
-        this.availableApplications = this.applicationsService.getAvailableApplications(true).pipe(
-            map(val => {
+
+        const admin = await firstValueFrom(this.authService.admin);
+
+        const filterInvalidApps = (ls: ApplicationInfo[]) => {
+            return admin ? ls : ls.filter(app => app.valid);
+        }
+
+        this.availableApplications = this.applicationsService.getAvailableApplications(true)
+            .pipe(map(ls => filterInvalidApps(ls)))
+            .pipe(map(val => {
                 this.appListLoading = false;
                 return val;
             })
-        );
+            );
         this.userRequests = this.applicationsService
             .getUserApplicationOwnerRequests()
             .pipe(map(requests => requests.filter(req => relevant(req))));
@@ -148,7 +158,7 @@ export class ApplicationsComponent implements OnInit {
 
         this.currentEnv = this.environmentsService.getCurrentEnvironment();
 
-        this.applicationsService.refresh().then();
+        await this.applicationsService.refresh();
     }
 
     submitRequest(): Promise<any> {

--- a/ui/src/app/layout/topics/schemasection/schema-section.component.spec.ts
+++ b/ui/src/app/layout/topics/schemasection/schema-section.component.spec.ts
@@ -73,7 +73,9 @@ describe('SchemaSectionComponent', () => {
 
                 name: 'app1',
 
-                aliases: ['a1']
+                aliases: ['a1'],
+
+                valid: true
             },
 
             createdTimestamp: 'string',

--- a/ui/src/app/layout/topics/topicmetadatatable/topic-metadata-table.component.html
+++ b/ui/src/app/layout/topics/topicmetadatatable/topic-metadata-table.component.html
@@ -51,12 +51,7 @@
         <tr>
             <th scope="row">{{ 'Owning Application' | translate }}</th>
             <td>
-                <a *ngIf="topic.ownerApplication?.infoUrl; else infoUrlText"
-                   [href]="topic.ownerApplication?.infoUrl"
-                   target="_blank">{{ topic.ownerApplication?.name }}</a>
-                <ng-template #infoUrlText>
-                    <span>{{ topic.ownerApplication?.name }}</span>
-                </ng-template>
+                <app-app-link [app]="topic.ownerApplication"></app-app-link>
             </td>
         </tr>
         <tr *ngIf="topic.producers?.length > 0">

--- a/ui/src/app/layout/topics/topics.component.html
+++ b/ui/src/app/layout/topics/topics.component.html
@@ -49,14 +49,8 @@
                         </td>
                         <td>{{topic.topicType | translate}}</td>
                         <td class="col-2">
-                            <a *ngIf="topic.ownerApplication && topic.ownerApplication.infoUrl"
-                               [href]="topic.ownerApplication.infoUrl" target="_blank">
-                                <ngb-highlight [result]="topic.ownerApplication.name"
-                                               [term]="searchData.searchTerm"></ngb-highlight>
-                            </a>
-                            <ngb-highlight *ngIf="!topic.ownerApplication || !topic.ownerApplication.infoUrl"
-                                           [result]="topic.ownerApplication ? topic.ownerApplication.name : ''"
-                                           [term]="searchData.searchTerm"></ngb-highlight>
+                            <app-app-link [app]="topic.ownerApplication"
+                                          [highlightText]="searchData.searchTerm"></app-app-link>
                         </td>
                     </tr>
                 </tbody>

--- a/ui/src/app/layout/topics/topics.module.ts
+++ b/ui/src/app/layout/topics/topics.module.ts
@@ -17,6 +17,7 @@ import { SubscriptionSectionComponent } from './subscribesection/subscribe-secti
 import { DeprecationComponent } from './deprecation/deprecation.component';
 import { DeleteTopicComponent } from './deletetopic/delete-topic.component';
 import { TopicMultipleProducerComponent } from './deletetopic/multiappproducer/topic-multiple-producer.component';
+import { AppLinkModule } from '../../shared/modules/app-link/app-link.module';
 
 export const getHighlightLanguages = () => ({
     json: () => import('highlight.js/lib/languages/json')
@@ -24,7 +25,7 @@ export const getHighlightLanguages = () => ({
 
 @NgModule({
     imports: [CommonModule, TopicsRoutingModule, TranslateModule, FormsModule, NgbModule,
-        SpinnerWhileModule, HighlightModule],
+        SpinnerWhileModule, HighlightModule, AppLinkModule],
     declarations: [TopicsComponent, TableSortDirective, SingleTopicComponent,
         TopicConfigEditorComponent, SchemaSectionComponent, TopicMetadataTableComponent,
         SubscriptionSectionComponent, DeprecationComponent, DeleteTopicComponent, TopicMultipleProducerComponent]

--- a/ui/src/app/shared/modules/app-link/app-link.component.html
+++ b/ui/src/app/shared/modules/app-link/app-link.component.html
@@ -1,0 +1,12 @@
+<a *ngIf="app?.infoUrl; else appNameText"
+   [href]="app?.infoUrl"
+   target="_blank">
+    <ng-container *ngTemplateOutlet="appNameText">
+    </ng-container>
+</a>
+<ng-template #appNameText>
+    <ngb-highlight *ngIf="highlightText" [result]="app?.name" [term]="highlightText"></ngb-highlight>
+    <span *ngIf="!highlightText">{{ app?.name }}</span>
+</ng-template>
+<i class="fa-solid fa-triangle-exclamation text-danger ms-1" *ngIf="!app.valid"
+   [title]="'INVALID_APP_TOOLTIP' | translate"></i>

--- a/ui/src/app/shared/modules/app-link/app-link.component.ts
+++ b/ui/src/app/shared/modules/app-link/app-link.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { ApplicationInfo } from '../../services/applications.service';
+
+@Component({
+    selector: 'app-app-link',
+    templateUrl: './app-link.component.html',
+    styleUrls: ['./app-link.component.scss']
+})
+export class AppLinkComponent {
+
+    @Input() app: ApplicationInfo;
+
+    @Input() highlightText?: string;
+
+}

--- a/ui/src/app/shared/modules/app-link/app-link.module.ts
+++ b/ui/src/app/shared/modules/app-link/app-link.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AppLinkComponent } from './app-link.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { NgbHighlight } from '@ng-bootstrap/ng-bootstrap';
+
+@NgModule({
+    imports: [CommonModule, TranslateModule, NgbHighlight],
+    exports: [
+        AppLinkComponent
+    ],
+    declarations: [AppLinkComponent]
+})
+export class AppLinkModule {
+}

--- a/ui/src/app/shared/services/applications.service.ts
+++ b/ui/src/app/shared/services/applications.service.ts
@@ -13,6 +13,8 @@ export interface ApplicationInfo {
     infoUrl?: string;
 
     aliases: string[];
+
+    valid: boolean;
 }
 
 export interface BusinessCapabilityInfo {

--- a/ui/src/assets/i18n/de.json
+++ b/ui/src/assets/i18n/de.json
@@ -300,6 +300,7 @@
     "APP_SUBSCRIPTION_CANCELLED": "Der Anwendung wurden die Rechte für dieses Topic entzogen.",
     "APP_SUBSCRIPTION_CANNOT_BE_REVOKED": "Der Anwendung konnten die Rechte für dieses Topic nicht entzogen werden.",
     "APP_SUCCESSFUL_TOPIC_APPROVED": "Die Anwendung wurde erfolgreich für dieses Topic freigegeben.",
-    "APP_TOPIC_APPROVED_FAILED": "Die Anwendung konnte nicht für dieses Topic freigegeben werden'"
+    "APP_TOPIC_APPROVED_FAILED": "Die Anwendung konnte nicht für dieses Topic freigegeben werden'",
+    "INVALID_APP_TOOLTIP": "Diese Anwendung sollte nicht mehr verwendet werden."
 }
 

--- a/ui/src/assets/i18n/en.json
+++ b/ui/src/assets/i18n/en.json
@@ -207,6 +207,7 @@
     "APP_SUBSCRIPTION_CANCELLED": "The application's rights for this topic have been revoked.",
     "APP_SUBSCRIPTION_CANNOT_BE_REVOKED": "The application's rights for this topic could not be revoked.",
     "APP_SUCCESSFUL_TOPIC_APPROVED": "The application was successfully approved for this topic.",
-    "APP_TOPIC_APPROVED_FAILED": "The application could not be approved for this topic"
+    "APP_TOPIC_APPROVED_FAILED": "The application could not be approved for this topic",
+    "INVALID_APP_TOOLTIP": "This application should no longer be used."
 }
 


### PR DESCRIPTION
This change introduces a flag "valid" for the `KnownApplication` interface. By default (for backwards compatibility), this flag is `true` (e.g. when `null` is stored in the `known-applications` topic). Applications having this flag set to `false` shall be treated as "unsafe to use" in the context of Galapagos, meaning:

* They will be marked with a red exclamation mark whereever they are mentioned (the marker has a tooltip explaining that the application should no longer be used)
* They are no longer available in the drop-down box for selecting an application for a new Application Topic Owner Request (Admins will still have them available, but also marked with an exclamation mark).

Supporting services filling the `known-applications` topic (or you using the `import-known-applications` admin job) now can e.g. set this flag to `false` when the application has reached its EOL.

To unify the rendering of application names / links in the UI, a new component, <code>AppLink</code>, has been introduced, including the marker if the application is marked as invalid.