### PR TITLE
Add missing variable for topic changed mail subjects

### DIFF
--- a/src/main/java/com/hermesworld/ais/galapagos/notifications/impl/NotificationEventListener.java
+++ b/src/main/java/com/hermesworld/ais/galapagos/notifications/impl/NotificationEventListener.java
@@ -280,14 +280,15 @@ public class NotificationEventListener
     private CompletableFuture<Void> handleTopicChange(TopicEvent event, String changeText) {
         String environmentId = event.getContext().getKafkaCluster().getId();
         String topicName = event.getMetadata().getName();
+        String topicNameAbbreviated = abbreviateTopicName(topicName);
         String userName = event.getContext().getContextValue(USER_NAME_KEY).map(Object::toString).orElse(unknownUser);
         String environmentName = kafkaClusters.getEnvironmentMetadata(environmentId)
                 .map(KafkaEnvironmentConfig::getName).orElse(unknownEnv);
 
-        // TODO externalize strings
         NotificationParams params = new NotificationParams("topic-changed");
         params.addVariable("user_name", userName);
         params.addVariable("topic_name", topicName);
+        params.addVariable("topic_name_abbreviated", topicNameAbbreviated);
         params.addVariable("change_action_text", changeText);
         params.addVariable("galapagos_topic_url",
                 buildUIUrl(event, "/topics/" + topicName + "?environment=" + environmentId));

--- a/src/main/resources/mailtemplates/de/topic-changed.html
+++ b/src/main/resources/mailtemplates/de/topic-changed.html
@@ -7,6 +7,7 @@
 </head>
 <!--/*@thymesVar id="user_name" type="java.lang.String"*/-->
 <!--/*@thymesVar id="topic_name" type="java.lang.String"*/-->
+<!--/*@thymesVar id="topic_name_abbreviated" type="java.lang.String"*/-->
 <!--/*@thymesVar id="change_action_text" type="java.lang.String"*/-->
 <!--/*@thymesVar id="galapagos_topic_url" type="java.lang.String"*/-->
 <!--/*@thymesVar id="environment_name" type="java.lang.String"*/-->

--- a/src/test/java/com/hermesworld/ais/galapagos/notifications/impl/NotificationEventListenerTest.java
+++ b/src/test/java/com/hermesworld/ais/galapagos/notifications/impl/NotificationEventListenerTest.java
@@ -113,7 +113,8 @@ class NotificationEventListenerTest {
                 .contains("some change description goes here"));
         assertFalse(
                 params.getVariables().get("change_action_text").toString().contains("Keine Beschreibung angegeben"));
-        assertNotNull(params.getVariables().get("topic_name_abbreviated"), "topic_name_abbreviated must be set for topic-changed e-mail template");
+        assertNotNull(params.getVariables().get("topic_name_abbreviated"),
+                "topic_name_abbreviated must be set for topic-changed e-mail template");
     }
 
     @Test

--- a/src/test/java/com/hermesworld/ais/galapagos/notifications/impl/NotificationEventListenerTest.java
+++ b/src/test/java/com/hermesworld/ais/galapagos/notifications/impl/NotificationEventListenerTest.java
@@ -113,7 +113,7 @@ class NotificationEventListenerTest {
                 .contains("some change description goes here"));
         assertFalse(
                 params.getVariables().get("change_action_text").toString().contains("Keine Beschreibung angegeben"));
-
+        assertNotNull(params.getVariables().get("topic_name_abbreviated"), "topic_name_abbreviated must be set for topic-changed e-mail template");
     }
 
     @Test


### PR DESCRIPTION
This fixes the issue with latest (non-released) version that e-mail subjects contained "null" instead of the correct (abbreviated) topic name.